### PR TITLE
Fix compilation error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,15 +283,15 @@ impl<'attrs, 'action> Fui<'attrs, 'action> {
         let mut sub_cmds: Vec<clap::App> = Vec::new();
         for action in self.actions.values() {
             let args = action.form.as_ref().unwrap().fields2clap_args();
-            let sub_cmd = clap::SubCommand::with_name(action.name.as_ref())
-                .about(action.help.as_ref())
+            let sub_cmd = clap::SubCommand::with_name(action.name)
+                .about(action.help)
                 .args(args.as_slice());
             sub_cmds.push(sub_cmd);
         }
-        clap::App::new(self.name.as_ref())
-            .version(self.version.as_ref())
-            .about(self.about.as_ref())
-            .author(self.author.as_ref())
+        clap::App::new(self.name)
+            .version(self.version)
+            .about(self.about)
+            .author(self.author)
             .subcommands(sub_cmds)
     }
 


### PR DESCRIPTION
This PR fixes an issue I've had compiling this library. Also removed a few unnecessary `as_ref`'s while I was at it.

```
> rustc --version
rustc 1.36.0 (a53f9df32 2019-07-03)
```

```
> cargo check
    Checking fui v1.0.0 (/Users/davidlewis/Developer/Learning/fui)
error[E0283]: type annotations required: cannot resolve `str: std::convert::AsRef<_>`
   --> src/lib.rs:291:34
    |
291 |         clap::App::new(self.name.as_ref())
    |                                  ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0283`.
error: Could not compile `fui`.
```